### PR TITLE
[HUST CSE][filesystem-sample] Fix an issue where "dfs_posix.h" is missing

### DIFF
--- a/mkdir_sample.c
+++ b/mkdir_sample.c
@@ -19,7 +19,7 @@
 
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/mkdir_sample.c
+++ b/mkdir_sample.c
@@ -18,7 +18,9 @@
 */
 
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void mkdir_sample(void)
 {

--- a/mkdir_sample.c
+++ b/mkdir_sample.c
@@ -18,9 +18,11 @@
 */
 
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void mkdir_sample(void)
 {

--- a/opendir_sample.c
+++ b/opendir_sample.c
@@ -17,7 +17,9 @@
  * 若读取目录成功，返回该目录结构，若读取目录失败，返回RT_NULL。
 */
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void opendir_sample(void)
 {

--- a/opendir_sample.c
+++ b/opendir_sample.c
@@ -18,7 +18,7 @@
 */
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/opendir_sample.c
+++ b/opendir_sample.c
@@ -17,9 +17,11 @@
  * 若读取目录成功，返回该目录结构，若读取目录失败，返回RT_NULL。
 */
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void opendir_sample(void)
 {

--- a/readdir_sample.c
+++ b/readdir_sample.c
@@ -18,7 +18,9 @@
  * 此外，每读取一次目录，目录流的指针位置将自动往后递推1 个位置。
 */
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void readdir_sample(void)
 {

--- a/readdir_sample.c
+++ b/readdir_sample.c
@@ -18,9 +18,11 @@
  * 此外，每读取一次目录，目录流的指针位置将自动往后递推1 个位置。
 */
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void readdir_sample(void)
 {

--- a/readdir_sample.c
+++ b/readdir_sample.c
@@ -19,7 +19,7 @@
 */
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/readwrite_sample.c
+++ b/readwrite_sample.c
@@ -14,7 +14,9 @@
  */
 
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void readwrite_sample(void)
 {

--- a/readwrite_sample.c
+++ b/readwrite_sample.c
@@ -15,7 +15,7 @@
 
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/readwrite_sample.c
+++ b/readwrite_sample.c
@@ -14,9 +14,11 @@
  */
 
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void readwrite_sample(void)
 {

--- a/rename_sample.c
+++ b/rename_sample.c
@@ -18,7 +18,9 @@
  *
 */
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void rename_sample(void)
 {

--- a/rename_sample.c
+++ b/rename_sample.c
@@ -19,7 +19,7 @@
 */
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/rename_sample.c
+++ b/rename_sample.c
@@ -18,9 +18,11 @@
  *
 */
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void rename_sample(void)
 {

--- a/stat_sample.c
+++ b/stat_sample.c
@@ -18,7 +18,7 @@
 */
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/stat_sample.c
+++ b/stat_sample.c
@@ -17,9 +17,11 @@
  * 复制到buf 指针所指的结构中(struct stat)。
 */
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 static void stat_sample(void)
 {

--- a/stat_sample.c
+++ b/stat_sample.c
@@ -17,7 +17,9 @@
  * 复制到buf 指针所指的结构中(struct stat)。
 */
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 static void stat_sample(void)
 {

--- a/tell_seek_dir_sample.c
+++ b/tell_seek_dir_sample.c
@@ -16,7 +16,9 @@
  * void seekdir(DIR *d, off_t offset); 设置下次读取目录的位置
 */
 #include <rtthread.h>
-#include <dfs_posix.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+/* 当需要使用文件操作时，需要包含下面两个头文件 */
+#include <unistd.h>
+#include <fcntl.h>
 
 /* 假设文件操作是在一个线程中完成 */
 static void telldir_sample(void)

--- a/tell_seek_dir_sample.c
+++ b/tell_seek_dir_sample.c
@@ -17,7 +17,7 @@
 */
 #include <rtthread.h>
 #if RT_VER_NUM >= 0x40100
-#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#include <fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
 #else
 #include <dfs_posix.h>
 #endif /*RT_VER_NUM >= 0x40100*/

--- a/tell_seek_dir_sample.c
+++ b/tell_seek_dir_sample.c
@@ -16,9 +16,11 @@
  * void seekdir(DIR *d, off_t offset); 设置下次读取目录的位置
 */
 #include <rtthread.h>
-/* 当需要使用文件操作时，需要包含下面两个头文件 */
-#include <unistd.h>
-#include <fcntl.h>
+#if RT_VER_NUM >= 0x40100
+#include <sys/_default_fcntl.h> /* 当需要使用文件操作时，需要包含这个头文件 */
+#else
+#include <dfs_posix.h>
+#endif /*RT_VER_NUM >= 0x40100*/
 
 /* 假设文件操作是在一个线程中完成 */
 static void telldir_sample(void)


### PR DESCRIPTION
解决了由于版本更新，导致dfs_posix.h头文件缺失的问题。
使用了unistd.h和fcntl.h两个头文件来解决依赖问题。